### PR TITLE
Fix Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ dist/libflac$(LIB_VERSION)-$(FLAC_VERSION).min.wasm.js: $(FLAC) $(PREFILE) $(POS
 dist/libflac$(LIB_VERSION)-$(FLAC_VERSION).dev.wasm.js: $(FLAC) $(PREFILE) $(POSTFILE)
 	$(EMCC) $(EMCC_MAX_OPT_LEVEL) $(EMCC_OPTS_WASM_DEFAULT) --pre-js $(PREFILE) --post-js $(POSTFILE) $(FLAC)/src/libFLAC/.libs/libFLAC-static.a -o $@
 
-# custom builds that includ OGG
+# custom builds that includes OGG
 
 dist/libflac$(LIB_VERSION)-vs-$(FLAC_VERSION).js: $(FLAC) $(PREFILE) $(POSTFILE)
 	$(EMCC) $(EMCC_DEF_OPT_LEVEL) $(EMCC_OPTS) -s USE_OGG=1 --pre-js $(PREFILE) --post-js $(POSTFILE) $(FLAC)/src/libFLAC/.libs/libFLAC-static.a -o $@

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 EMCC:=emcc
 EMCC_DEF_OPT_LEVEL:=-O1
-EMCC_MAX_OPT_LEVEL:=-O0 -g4
+EMCC_MAX_OPT_LEVEL:=-O0
+EMCC_MAX_OPT_LEVEL_ASMJS=$(EMCC_MAX_OPT_LEVEL) -g3
+EMCC_MAX_OPT_LEVEL_WASM=$(EMCC_MAX_OPT_LEVEL) -g4
 EMCC_MIN_OPT_LEVEL:=-O3
 EMCC_OPTS_GENERAL:=-s NO_EXIT_RUNTIME=1 -s LINKABLE=1 -s RESERVED_FUNCTION_POINTERS=5 -s ALLOW_MEMORY_GROWTH=1 -s 'EXTRA_EXPORTED_RUNTIME_METHODS=["ccall","cwrap","getValue","setValue"]' -s EXPORTED_FUNCTIONS='["_FLAC__stream_encoder_set_verify","_FLAC__stream_encoder_set_compression_level","_FLAC__stream_encoder_set_blocksize","_FLAC__stream_encoder_new","_FLAC__stream_encoder_set_channels","_FLAC__stream_encoder_set_bits_per_sample","_FLAC__stream_encoder_set_sample_rate","_FLAC__stream_encoder_set_total_samples_estimate","_FLAC__stream_decoder_new","_FLAC__stream_decoder_set_md5_checking","_FLAC__stream_encoder_init_stream","_FLAC__stream_decoder_init_stream","_FLAC__stream_encoder_process_interleaved","_FLAC__stream_decoder_process_single","_FLAC__stream_decoder_process_until_end_of_stream","_FLAC__stream_decoder_process_until_end_of_metadata","_FLAC__stream_decoder_get_state","_FLAC__stream_encoder_get_state","_FLAC__stream_decoder_get_md5_checking","_FLAC__stream_encoder_finish","_FLAC__stream_decoder_finish","_FLAC__stream_decoder_reset","_FLAC__stream_encoder_delete","_FLAC__stream_decoder_delete"]'
 EMCC_OPTS_ASMJS_DEV:=$(EMCC_OPTS_GENERAL) -s WASM=0
@@ -32,7 +34,7 @@ dist/libflac$(LIB_VERSION)-$(FLAC_VERSION).min.js: $(FLAC) $(PREFILE) $(POSTFILE
 	$(EMCC) $(EMCC_MIN_OPT_LEVEL) $(EMCC_OPTS_ASMJS_DEFAULT) --pre-js $(PREFILE) --post-js $(POSTFILE) $(wildcard $(FLAC)/src/libFLAC/.libs/libFLAC-static.a) -o $@
 
 dist/libflac$(LIB_VERSION)-$(FLAC_VERSION).dev.js: $(FLAC) $(PREFILE) $(POSTFILE)
-	$(EMCC) $(EMCC_MAX_OPT_LEVEL) $(EMCC_OPTS_ASMJS_DEV) --pre-js $(PREFILE) --post-js $(POSTFILE) $(wildcard $(FLAC)/src/libFLAC/.libs/libFLAC-static.a) -o $@
+	$(EMCC) $(EMCC_MAX_OPT_LEVEL_ASMJS) $(EMCC_OPTS_ASMJS_DEV) --pre-js $(PREFILE) --post-js $(POSTFILE) $(wildcard $(FLAC)/src/libFLAC/.libs/libFLAC-static.a) -o $@
 
 # wasm builds
 
@@ -45,7 +47,7 @@ dist/libflac$(LIB_VERSION)-$(FLAC_VERSION).min.wasm.js: $(FLAC) $(PREFILE) $(POS
 	$(EMCC) $(EMCC_MIN_OPT_LEVEL) $(EMCC_OPTS_WASM_DEFAULT) --pre-js $(PREFILE) --post-js $(POSTFILE) $(FLAC)/src/libFLAC/.libs/libFLAC-static.a -o $@
 
 dist/libflac$(LIB_VERSION)-$(FLAC_VERSION).dev.wasm.js: $(FLAC) $(PREFILE) $(POSTFILE)
-	$(EMCC) $(EMCC_MAX_OPT_LEVEL) $(EMCC_OPTS_WASM_DEFAULT) --pre-js $(PREFILE) --post-js $(POSTFILE) $(FLAC)/src/libFLAC/.libs/libFLAC-static.a -o $@
+	$(EMCC) $(EMCC_MAX_OPT_LEVEL_WASM) $(EMCC_OPTS_WASM_DEFAULT) --pre-js $(PREFILE) --post-js $(POSTFILE) $(FLAC)/src/libFLAC/.libs/libFLAC-static.a -o $@
 
 # custom builds that includes OGG
 

--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ emmake: $(FLAC)
 $(FLAC): $(FLAC).tar.xz
 	$(XZ) -dc $@.tar.xz | $(TAR) -xv && \
 	cd $@ && \
-	$(EMCONFIGURE) ./configure --disable-asm-optimizations --disable-3dnow --disable-altivec --disable-thorough-tests --disable-doxygen-docs --disable-xmms-plugin --disable-cpplibs --disable-ogg --disable-oggtest && \
+	$(EMCONFIGURE) ./configure --host=asmjs --disable-asm-optimizations --disable-3dnow --disable-altivec --disable-thorough-tests --disable-doxygen-docs --disable-xmms-plugin --disable-cpplibs --disable-ogg --disable-oggtest && \
 	$(EMMAKE) make
 
 $(FLAC).tar.xz:

--- a/Makefile
+++ b/Makefile
@@ -26,34 +26,34 @@ all: all_asmjs all_wasm
 all_asmjs: dist/libflac$(LIB_VERSION)-$(FLAC_VERSION).js dist/libflac$(LIB_VERSION)-$(FLAC_VERSION).min.js dist/libflac$(LIB_VERSION)-$(FLAC_VERSION).dev.js
 
 dist/libflac$(LIB_VERSION)-$(FLAC_VERSION).js: $(FLAC) $(PREFILE) $(POSTFILE)
-	$(EMCC) $(EMCC_DEF_OPT_LEVEL) $(EMCC_OPTS_ASMJS_DEFAULT) --pre-js $(PREFILE) --post-js $(POSTFILE) $(wildcard $(FLAC)/src/libFLAC/.libs/*.o) -o $@
+	$(EMCC) $(EMCC_DEF_OPT_LEVEL) $(EMCC_OPTS_ASMJS_DEFAULT) --pre-js $(PREFILE) --post-js $(POSTFILE) $(wildcard $(FLAC)/src/libFLAC/.libs/libFLAC-static.a) -o $@
 
 dist/libflac$(LIB_VERSION)-$(FLAC_VERSION).min.js: $(FLAC) $(PREFILE) $(POSTFILE)
-	$(EMCC) $(EMCC_MIN_OPT_LEVEL) $(EMCC_OPTS_ASMJS_DEFAULT) --pre-js $(PREFILE) --post-js $(POSTFILE) $(wildcard $(FLAC)/src/libFLAC/.libs/*.o) -o $@
+	$(EMCC) $(EMCC_MIN_OPT_LEVEL) $(EMCC_OPTS_ASMJS_DEFAULT) --pre-js $(PREFILE) --post-js $(POSTFILE) $(wildcard $(FLAC)/src/libFLAC/.libs/libFLAC-static.a) -o $@
 
 dist/libflac$(LIB_VERSION)-$(FLAC_VERSION).dev.js: $(FLAC) $(PREFILE) $(POSTFILE)
-	$(EMCC) $(EMCC_MAX_OPT_LEVEL) $(EMCC_OPTS_ASMJS_DEV) --pre-js $(PREFILE) --post-js $(POSTFILE) $(wildcard $(FLAC)/src/libFLAC/.libs/*.o) -o $@
+	$(EMCC) $(EMCC_MAX_OPT_LEVEL) $(EMCC_OPTS_ASMJS_DEV) --pre-js $(PREFILE) --post-js $(POSTFILE) $(wildcard $(FLAC)/src/libFLAC/.libs/libFLAC-static.a) -o $@
 
 # wasm builds
 
 all_wasm: dist/libflac$(LIB_VERSION)-$(FLAC_VERSION).wasm.js dist/libflac$(LIB_VERSION)-$(FLAC_VERSION).min.wasm.js dist/libflac$(LIB_VERSION)-$(FLAC_VERSION).dev.wasm.js
 
 dist/libflac$(LIB_VERSION)-$(FLAC_VERSION).wasm.js: $(FLAC) $(PREFILE) $(POSTFILE)
-	$(EMCC) $(EMCC_DEF_OPT_LEVEL) $(EMCC_OPTS_WASM_DEFAULT) --pre-js $(PREFILE) --post-js $(POSTFILE) $(wildcard $(FLAC)/src/libFLAC/.libs/*.o) -o $@
+	$(EMCC) $(EMCC_DEF_OPT_LEVEL) $(EMCC_OPTS_WASM_DEFAULT) --pre-js $(PREFILE) --post-js $(POSTFILE) $(FLAC)/src/libFLAC/.libs/libFLAC-static.a -o $@
 
 dist/libflac$(LIB_VERSION)-$(FLAC_VERSION).min.wasm.js: $(FLAC) $(PREFILE) $(POSTFILE)
-	$(EMCC) $(EMCC_MIN_OPT_LEVEL) $(EMCC_OPTS_WASM_DEFAULT) --pre-js $(PREFILE) --post-js $(POSTFILE) $(wildcard $(FLAC)/src/libFLAC/.libs/*.o) -o $@
+	$(EMCC) $(EMCC_MIN_OPT_LEVEL) $(EMCC_OPTS_WASM_DEFAULT) --pre-js $(PREFILE) --post-js $(POSTFILE) $(FLAC)/src/libFLAC/.libs/libFLAC-static.a -o $@
 
 dist/libflac$(LIB_VERSION)-$(FLAC_VERSION).dev.wasm.js: $(FLAC) $(PREFILE) $(POSTFILE)
-	$(EMCC) $(EMCC_MAX_OPT_LEVEL) $(EMCC_OPTS_WASM_DEFAULT) --pre-js $(PREFILE) --post-js $(POSTFILE) $(wildcard $(FLAC)/src/libFLAC/.libs/*.o) -o $@
+	$(EMCC) $(EMCC_MAX_OPT_LEVEL) $(EMCC_OPTS_WASM_DEFAULT) --pre-js $(PREFILE) --post-js $(POSTFILE) $(FLAC)/src/libFLAC/.libs/libFLAC-static.a -o $@
 
 # custom builds that includ OGG
 
 dist/libflac$(LIB_VERSION)-vs-$(FLAC_VERSION).js: $(FLAC) $(PREFILE) $(POSTFILE)
-	$(EMCC) $(EMCC_DEF_OPT_LEVEL) $(EMCC_OPTS) -s USE_OGG=1 --pre-js $(PREFILE) --post-js $(POSTFILE) $(wildcard $(FLAC)/src/libFLAC/Emscripten/Release/*.o) -o $@
+	$(EMCC) $(EMCC_DEF_OPT_LEVEL) $(EMCC_OPTS) -s USE_OGG=1 --pre-js $(PREFILE) --post-js $(POSTFILE) $(FLAC)/src/libFLAC/.libs/libFLAC-static.a -o $@
 
 dist/libflac$(LIB_VERSION)-vs-$(FLAC_VERSION).min.js: $(FLAC) $(PREFILE) $(POSTFILE)
-	$(EMCC) $(EMCC_MIN_OPT_LEVEL) $(EMCC_OPTS) -s USE_OGG=1 --pre-js $(PREFILE) --post-js $(POSTFILE) $(wildcard $(FLAC)/src/libFLAC/Emscripten/Release/*.o) -o $@
+	$(EMCC) $(EMCC_MIN_OPT_LEVEL) $(EMCC_OPTS) -s USE_OGG=1 --pre-js $(PREFILE) --post-js $(POSTFILE) $(FLAC)/src/libFLAC/.libs/libFLAC-static.a -o $@
 
 emccvs: dist/libflac$(LIB_VERSION)-vs-$(FLAC_VERSION).js dist/libflac$(LIB_VERSION)-vs-$(FLAC_VERSION).min.js
 

--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,8 @@ EMCC_MAX_OPT_LEVEL:=-O0 -g4
 EMCC_MIN_OPT_LEVEL:=-O3
 EMCC_OPTS_GENERAL:=-s NO_EXIT_RUNTIME=1 -s LINKABLE=1 -s RESERVED_FUNCTION_POINTERS=5 -s ALLOW_MEMORY_GROWTH=1 -s 'EXTRA_EXPORTED_RUNTIME_METHODS=["ccall","cwrap","getValue","setValue"]' -s EXPORTED_FUNCTIONS='["_FLAC__stream_encoder_set_verify","_FLAC__stream_encoder_set_compression_level","_FLAC__stream_encoder_set_blocksize","_FLAC__stream_encoder_new","_FLAC__stream_encoder_set_channels","_FLAC__stream_encoder_set_bits_per_sample","_FLAC__stream_encoder_set_sample_rate","_FLAC__stream_encoder_set_total_samples_estimate","_FLAC__stream_decoder_new","_FLAC__stream_decoder_set_md5_checking","_FLAC__stream_encoder_init_stream","_FLAC__stream_decoder_init_stream","_FLAC__stream_encoder_process_interleaved","_FLAC__stream_decoder_process_single","_FLAC__stream_decoder_process_until_end_of_stream","_FLAC__stream_decoder_process_until_end_of_metadata","_FLAC__stream_decoder_get_state","_FLAC__stream_encoder_get_state","_FLAC__stream_decoder_get_md5_checking","_FLAC__stream_encoder_finish","_FLAC__stream_decoder_finish","_FLAC__stream_decoder_reset","_FLAC__stream_encoder_delete","_FLAC__stream_decoder_delete"]'
 EMCC_OPTS_ASMJS_DEV:=$(EMCC_OPTS_GENERAL) -s WASM=0
-EMCC_OPTS_ASMJS_DEFAULT:=$(EMCC_OPTS_ASMJS_DEV) -s "BINARYEN_TRAP_MODE='clamp'"
-EMCC_OPTS_WASM_DEFAULT:=$(EMCC_OPTS_GENERAL) -s "BINARYEN_TRAP_MODE='clamp'"
+EMCC_OPTS_ASMJS_DEFAULT:=$(EMCC_OPTS_ASMJS_DEV)
+EMCC_OPTS_WASM_DEFAULT:=$(EMCC_OPTS_GENERAL)
 EMCONFIGURE:=emconfigure
 EMMAKE:=emmake
 TAR:=tar


### PR DESCRIPTION
Hello,

I needed to compile libflac.js. Here are the changes I needed to apply  to the Makefile to compile with the latest version of emscripten on GNU/Linux.

I haven't tried if libflac.js as compiled with these changes works. More specifically, I had to remove BINARYEN_TRAP_MODE='clamp' , and I had to change the wildcard *.o to `libFLAC-static.a`. I don't know if it is correct.