### PR TITLE
fix: narrow return type to resolve type error

### DIFF
--- a/src/utils/data-utils.ts
+++ b/src/utils/data-utils.ts
@@ -7,7 +7,7 @@ export function getLength(recBuffers: Uint8Array[]) : number {
 	return recLength;
 }
 
-export function mergeBuffers(channelBuffer: Uint8Array[], recordingLength: number): Uint8Array {
+export function mergeBuffers(channelBuffer: Uint8Array[], recordingLength: number): Uint8Array<ArrayBuffer> {
 	var result = new Uint8Array(recordingLength);
 	var offset = 0;
 	var lng = channelBuffer.length;

--- a/src/utils/wav-utils.ts
+++ b/src/utils/wav-utils.ts
@@ -150,7 +150,7 @@ export function interleave(recBuffers: Uint8Array[][], channels: number, bitsPer
  *
  * @returns the WAV data incl. header
  */
-export function encodeWAV(samples: Uint8Array, sampleRate: number, channels: number, bitsPerSample: number): DataView {
+export function encodeWAV(samples: Uint8Array, sampleRate: number, channels: number, bitsPerSample: number): DataView<ArrayBuffer> {
 
 	var bytePerSample = bitsPerSample / 8;
 	var length = samples.length * samples.BYTES_PER_ELEMENT;


### PR DESCRIPTION
Typescript reports two errors when using the library.

```
 ERROR(TypeScript)  Type 'Uint8Array<ArrayBufferLike>' is not assignable to type 'BlobPart'.
  Type 'Uint8Array<ArrayBufferLike>' is not assignable to type 'ArrayBufferView<ArrayBuffer>'.
    Types of property 'buffer' are incompatible.
      Type 'ArrayBufferLike' is not assignable to type 'ArrayBuffer'.
        Type 'SharedArrayBuffer' is missing the following properties from type 'ArrayBuffer': resizable, resize, detached, transfer, transferToFixedLength
 FILE  .../node_modules/libflacjs/src/utils/flac-utils.ts:101:19

     99 | 	//convert buffers into one single buffer
    100 | 	const samples = mergeBuffers(recBuffers, recLength);
  > 101 | 	return new Blob([samples], {type: isOgg? 'audio/ogg' : 'audio/flac'});
        | 	                ^^^^^^^
    102 | }
    103 |
```

```
ERROR(TypeScript)  Type 'DataView<ArrayBufferLike>' is not assignable to type 'BlobPart'.
  Type 'DataView<ArrayBufferLike>' is not assignable to type 'ArrayBufferView<ArrayBuffer>'.
    Types of property 'buffer' are incompatible.
      Type 'ArrayBufferLike' is not assignable to type 'ArrayBuffer'.
        Type 'SharedArrayBuffer' is missing the following properties from type 'ArrayBuffer': resizable, resize, detached, transfer, transferToFixedLength
 FILE  .../node_modules/libflacjs/src/utils/wav-utils.ts:223:19

    221 | 	const samples = interleave(recBuffers, channels, bitsPerSample);
    222 | 	const dataView = encodeWAV(samples, sampleRate, channels, bitsPerSample);
  > 223 | 	return new Blob([dataView], {type: 'audio/wav'});
        | 	                ^^^^^^^^
    224 | }
    225 |
```

This presumably happens since TS 5.9 which made some [changes to `lib.d.ts`](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-9.html#libdts-changes)

> [...] ArrayBuffer has been changed in such a way that it is no longer a supertype of several different TypedArray types. This also includes subtypes of UInt8Array, such as Buffer from Node.js.

The solution is a small fix to narrow the return types to `ArrayBuffer` instead of the default `ArrayBufferLike` for container types, also described in the TS release-notes.

> Much of the time, the solution is to specify a more specific underlying buffer type instead of using the default ArrayBufferLike (i.e. explicitly writing out Uint8Array<ArrayBuffer> rather than a plain Uint8Array).